### PR TITLE
Json report

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ myproject/module2.py      10      3       70%   func3, func4, <lambda>
 -------------------------------------------------------
 TOTAL                     17      8       47%   
 ```
-
+Also ```json``` option can be used with ```--func_cov_report```. To get the output in a JSON file
+```bash
+pytest --func_cov=myproject --func_cov_report=json
+```
 # Configuration
 A list of function name patterns to ignore can be specified in pytest.ini.
 
@@ -62,3 +65,11 @@ ignore_func_names =
     ^myfunction$
 ```
 This will ignore all function names starting with "test_" and functions named "myfunction".
+
+You can specify the directory to save the function coverage report.
+
+Example
+```ini
+[pytest]
+json_path = public
+```

--- a/pytest_func_cov/plugin.py
+++ b/pytest_func_cov/plugin.py
@@ -100,7 +100,7 @@ class FuncCovPlugin:
         output_options = self.args.known_args_namespace.func_cov_report
         include_missing = "term-missing" in output_options
         include_json = "json" in output_options
-        
+
         tr = terminalreporter
         cwd = os.getcwd()
 
@@ -154,10 +154,10 @@ class FuncCovPlugin:
 
         args = ("TOTAL", total_funcs, total_miss, total_cover)
         if include_json:
-            report_data={
-                "total_funcs":total_funcs,
-                "total_miss":total_miss,
-                "total_cover":total_cover
+            report_data = {
+                "total_funcs": total_funcs,
+                "total_miss": total_miss,
+                "total_cover": total_cover,
             }
             with open("func_report.json", "w") as json_file:
                 json.dump(report_data, json_file, indent=4)

--- a/pytest_func_cov/plugin.py
+++ b/pytest_func_cov/plugin.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 
 from .tracking import FunctionIndexer, get_full_function_name
 
@@ -31,6 +32,15 @@ def pytest_addoption(parser):
         metavar="SOURCE",
         nargs="?",
         const=True,
+    )
+    group.addoption(
+        "--func_json",
+        dest="func_json",
+        action="append",
+        default=[],
+        metavar="SOURCE",
+        nargs="?",
+        help="Get Func Coverage in JSON"
     )
 
     parser.addini("ignore_func_names", "function names to ignore", "linelist", [])
@@ -151,7 +161,14 @@ class FuncCovPlugin:
             total_cover = 0
 
         args = ("TOTAL", total_funcs, total_miss, total_cover)
-
+        if self.args.known_args_namespace.func_json:
+            report_data={
+                "total_funcs":total_funcs,
+                "total_miss":total_miss,
+                "total_cover":total_cover
+            }
+            with open("func_report.json", "w") as json_file:
+                json.dump(report_data, json_file, indent=4)
         if include_missing:
             args += ("",)
 

--- a/pytest_func_cov/plugin.py
+++ b/pytest_func_cov/plugin.py
@@ -33,15 +33,6 @@ def pytest_addoption(parser):
         nargs="?",
         const=True,
     )
-    group.addoption(
-        "--func_json",
-        dest="func_json",
-        action="append",
-        default=[],
-        metavar="SOURCE",
-        nargs="?",
-        help="Get Func Coverage in JSON"
-    )
 
     parser.addini("ignore_func_names", "function names to ignore", "linelist", [])
 
@@ -108,7 +99,8 @@ class FuncCovPlugin:
         """
         output_options = self.args.known_args_namespace.func_cov_report
         include_missing = "term-missing" in output_options
-
+        include_json = "json" in output_options
+        
         tr = terminalreporter
         cwd = os.getcwd()
 
@@ -161,7 +153,7 @@ class FuncCovPlugin:
             total_cover = 0
 
         args = ("TOTAL", total_funcs, total_miss, total_cover)
-        if self.args.known_args_namespace.func_json:
+        if include_json:
             report_data={
                 "total_funcs":total_funcs,
                 "total_miss":total_miss,

--- a/pytest_func_cov/plugin.py
+++ b/pytest_func_cov/plugin.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import json
-
 from .tracking import FunctionIndexer, get_full_function_name
 
 
@@ -35,6 +34,7 @@ def pytest_addoption(parser):
     )
 
     parser.addini("ignore_func_names", "function names to ignore", "linelist", [])
+    parser.addini("json_path", "path for saving json file", "linelist", []) 
 
 
 def pytest_load_initial_conftests(early_config, parser, args):
@@ -47,6 +47,7 @@ class FuncCovPlugin:
     def __init__(self, args):
         self.args = args
         self.indexer = FunctionIndexer(args.getini("ignore_func_names"))
+        self.json_path = args.getini("json_path")
 
     def pytest_sessionstart(self, session):
         """
@@ -153,14 +154,23 @@ class FuncCovPlugin:
             total_cover = 0
 
         args = ("TOTAL", total_funcs, total_miss, total_cover)
+
         if include_json:
             report_data = {
                 "total_funcs": total_funcs,
                 "total_miss": total_miss,
                 "total_cover": total_cover,
             }
-            with open("func_report.json", "w") as json_file:
-                json.dump(report_data, json_file, indent=4)
+
+            try:
+                file_path = os.path.join(self.json_path[0], "func_report.json")
+                os.makedirs(self.json_path[0], exist_ok=True)
+                with open(file_path, "w") as json_file:
+                    json.dump(report_data, json_file, indent=4)
+            except IndexError:
+                with open("func_report.json", "w") as json_file:
+                    json.dump(report_data, json_file, indent=4)
+
         if include_missing:
             args += ("",)
 

--- a/pytest_func_cov/tracking.py
+++ b/pytest_func_cov/tracking.py
@@ -40,7 +40,7 @@ class FunctionCallMonitor:
             f (FunctionType): Function to track
             parent_class (Type): Parent class of the function if part of a
                 class; defaults to None
-        
+
         Raises:
             MonitoringError: if f seems to be a classmethod but it does not have
                 an __func__ attribute holding the wrapped method.
@@ -94,7 +94,7 @@ class FunctionCallMonitor:
     def called_functions(self):
         """
         Returns:
-            Tuple[Tuple[str, Tuple[FunctionType, ...]], ...]: all called registered 
+            Tuple[Tuple[str, Tuple[FunctionType, ...]], ...]: all called registered
                 functions, grouped by module
         """
         return tuple(
@@ -139,7 +139,7 @@ class FunctionCallMonitor:
                 originates
             source_function (str): Name of the function from where the call
                 originates
-        
+
         Returns:
             bool: True if the call was recorded, False otherwise.
         """
@@ -344,13 +344,13 @@ def get_methods_defined_in_class(cls):
 
 def find_modules(path):
     """
-    Discover all Python module files in a path. Uses os.walk to recursively traverse 
-    all the nested directories but does not follow symlinks. Returns a generator 
+    Discover all Python module files in a path. Uses os.walk to recursively traverse
+    all the nested directories but does not follow symlinks. Returns a generator
     of 2-tuples, (absolute_file_path, absolute_module_name).
 
     Args:
         path (str):
-    
+
     Returns:
         Generator[Tuple[str, str], None, None]
     """

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -99,7 +99,7 @@ def nested_package_directory():
     Returns
         Tuple[str, Tuple[Tuple[str, str], ...]]: First element is the absolute path
             to the created directory, and the second is a tuple of tuples, where the first
-            element is the absolute path to a .py file, and the second one is the name under 
+            element is the absolute path to a .py file, and the second one is the name under
             which is should be imported.
     """
     with tempfile.TemporaryDirectory() as package_folder:


### PR DESCRIPTION
Added new option ```json``` for ```--func_cov_report``` argument. Which will give a JSON file with function coverage report